### PR TITLE
⌨️ Convert Cursor layer to macOS, plus repo docs sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ glove80.sublime-project
 glove80.sublime-workspace
 
 .DS_Store
+
+# Local cache for firmware artifacts pulled via `gh run download`
+builds/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,18 @@ There is no local build target. Two GitHub Actions workflows handle everything:
 
 If you need to reproduce the firmware build locally, you need Nix and the `moergo-sc/zmk` repo cloned alongside as `src/`; then `nix-build config -o combined`. This is rarely worth doing — push and let CI build.
 
+### Monitoring & fetching the build artifact
+
+`gh` is installed and authenticated. After a push, **proactively** offer to monitor the run and pull the artifact down so the maintainer doesn't have to click through the Actions UI:
+
+```
+gh run list --branch <branch> --workflow build.yml --limit 1 --json databaseId,status,conclusion,headSha
+gh run watch <run-id> --exit-status        # blocks until completion, non-zero on failure
+gh run download <run-id> --dir ./builds/   # pulls the glove80-<branch>-build-<n>.<m>.uf2 artifact
+```
+
+Workflow: push → poll until a run appears for the new SHA → `watch` it → if green, download into `./builds/` and report the file path. If red, fetch the failing job's log (`gh run view <run-id> --log-failed`) and surface the relevant lines. Don't ask the maintainer to babysit the Actions tab.
+
 ## Architecture
 
 ### `config/glove80.keymap` is the only file most edits touch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,10 @@ Branch prefixes observed in history (use these — don't invent new ones):
 - `bugfix/<kebab-case-topic>` — for fixing broken behavior. Example: `bugfix/lower-not-working`.
 - `develop` — exists on the remote but is dormant; merges go directly from `feature/*` to `main`. Don't branch from `develop`.
 
+### Tagging
+
+Every notable change merged to `main` gets a sequential tag of the form **`v<N>-<kebab-case-topic>`** — the topic typically matches the branch name with the prefix dropped. Sequence is monotonic across the whole repo (not per-feature), so check `git tag --list | sort -V` to find the next number. Examples: `v1-hello-glove`, `v3-cursor-layer`, `v7-lower-bugfix`, `v12-shift-space-underscore`, `v13-cursor-layer-ubuntu`. Suggest the tag name when finishing a branch and offer to create it after merge.
+
 A few naming-convention notes that come from reading the keymap, not the branches:
 
 - **Behavior identifiers in `behaviors { }`** are `snake_case` and prefixed by what they do: `homey_*`, `index_*`, `thumb*`, `td_*` (tap-dance), `lk_*` (linger), `magic`, `shift_spc_uscr`. The `miryoku_*` labels in `label = "..."` are descriptive only — match them when adding new behaviors in the same family.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,21 @@ Help the maintainer **maintain, debug, and modify** their fancypants keyboard se
 
 There is no local build target. Two GitHub Actions workflows handle everything:
 
-- `.github/workflows/build.yml` — on every push and via `workflow_dispatch`. Checks out this repo plus `moergo-sc/zmk` at the pinned ref (`v24.02`) into `src/`, then runs `nix-build config -o combined` to produce `glove80.uf2`. The artifact is uploaded as `glove80-<branch>-build-<run>.<attempt>.uf2`. Flash that file to the keyboard.
-- `.github/workflows/draw-keymaps.yml` — on PRs to `main` that touch `config/*.keymap`, `config/*.dtsi`, or `keymap_drawer.config.yaml`. Calls `caksoylar/keymap-drawer`'s reusable workflow, which commits an updated `glove80.svg` and `glove80.yaml` back to the PR branch. Expect those two files to show up in diffs you didn't write.
+- `.github/workflows/build.yml` — `on: [push, workflow_dispatch]`. Checks out this repo plus `moergo-sc/zmk` at the pinned ref (`v24.02`) into `src/`, then runs `nix-build config -o combined` to produce `glove80.uf2`. The artifact is uploaded as `glove80-<branch>-build-<run>.<attempt>.uf2`. Flash that file to the keyboard.
+- `.github/workflows/draw-keymaps.yml` — on `pull_request` to `main` that touches `config/*.keymap`, `config/*.dtsi`, or `keymap_drawer.config.yaml`. Calls `caksoylar/keymap-drawer`'s reusable workflow, which commits an updated `glove80.svg` and `glove80.yaml` back to the PR branch. Expect those two files to show up in diffs you didn't write.
+
+**When does Build actually run?** Two non-obvious points (don't get this wrong — past confusion lives in commit `f05d2ba fix: don't build twice on pull-request open`):
+
+| Event                              | Build?                                                                              |
+| ---------------------------------- | ----------------------------------------------------------------------------------- |
+| Push to a feature branch           | ✅                                                                                   |
+| PR opened / synchronized           | ❌ — `pull_request` was intentionally removed from `build.yml` to stop double-builds |
+| `keymap-drawer render` auto-commit | ❌ — pushed by `GITHUB_TOKEN`, which Actions suppresses to prevent loops             |
+| Force-push / amend                 | ✅                                                                                   |
+| Merge to `main`                    | ✅                                                                                   |
+| Annotated tag push                 | ✅                                                                                   |
+
+So a typical feature-branch PR runs **2 Builds total** (initial push + merge). If you ever want a Build on PR open too, re-add `pull_request` to `build.yml`'s `on:`.
 
 If you need to reproduce the firmware build locally, you need Nix and the `moergo-sc/zmk` repo cloned alongside as `src/`; then `nix-build config -o combined`. This is rarely worth doing — push and let CI build.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,167 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## ⚠ This repo is public
+
+Everything in this directory ships to a public GitHub repo. **Do not write personal facts, real names, email addresses, host names, network details, work-context info, credentials, or anything else not strictly about Glove80/ZMK into any tracked file** — including this `CLAUDE.md`, the `README.md`, keymap comments, or commit messages. Treat the maintainer in third-person-neutral ("the maintainer", "the user") rather than by name. If a discussion needs context that's personal, hold it in conversation and don't persist it.
+
+## What this repo is
+
+A personal ZMK firmware configuration for the MoErgo Glove80 wireless split keyboard. There is no application source code — the "build" is a firmware compilation that runs in CI against an upstream ZMK checkout. Editing here means editing the keymap and rebuilding firmware, not running services or tests locally.
+
+## Your job in this repo
+
+Help the maintainer **maintain, debug, and modify** their fancypants keyboard setup. Concretely that means: tweaking keymaps and layers, adjusting hold-tap / tap-dance / home-row-mod timing and behavior, diagnosing why a key feels wrong (accidental shifts, missed taps, mod sticking), wiring new behaviors into the right layer at the right key position, and keeping the generated render in sync. Most "bugs" here are timing/ergonomic, not compile-time — when something feels off, suspect `tapping-term-ms`, `quick-tap-ms`, `flavor`, `hold-trigger-key-positions`, or `hold-trigger-on-release` before suspecting the binding itself.
+
+## Build & render
+
+There is no local build target. Two GitHub Actions workflows handle everything:
+
+- `.github/workflows/build.yml` — on every push and via `workflow_dispatch`. Checks out this repo plus `moergo-sc/zmk` at the pinned ref (`v24.02`) into `src/`, then runs `nix-build config -o combined` to produce `glove80.uf2`. The artifact is uploaded as `glove80-<branch>-build-<run>.<attempt>.uf2`. Flash that file to the keyboard.
+- `.github/workflows/draw-keymaps.yml` — on PRs to `main` that touch `config/*.keymap`, `config/*.dtsi`, or `keymap_drawer.config.yaml`. Calls `caksoylar/keymap-drawer`'s reusable workflow, which commits an updated `glove80.svg` and `glove80.yaml` back to the PR branch. Expect those two files to show up in diffs you didn't write.
+
+If you need to reproduce the firmware build locally, you need Nix and the `moergo-sc/zmk` repo cloned alongside as `src/`; then `nix-build config -o combined`. This is rarely worth doing — push and let CI build.
+
+## Architecture
+
+### `config/glove80.keymap` is the only file most edits touch
+
+It's a devicetree source file processed by the C preprocessor before ZMK compiles it. Important conventions:
+
+- **Layer indexes are `#define`s at the top.** Current layers: `Base` (0), `Lower` (1), `Cursor` (2), `Spaces` (3), `Gaming` (4), `LabVIEW` (5), `Magic` (6). Reordering these `#define`s silently rebinds every `&mo`/`&to`/`&lt` reference — change names, not the numeric order, unless you intend to remap.
+- **Custom behaviors live in `behaviors { ... }` blocks** (tap-dances, hold-taps, mod-morphs). The file has multiple `/ { ... };` root blocks that get merged by the devicetree compiler — that's normal, not a bug to clean up.
+- **Layer bindings** are inside `keymap { ... }` and laid out as a 2D grid of `&kp`/`&mo`/`&macro_*`/etc., one row per physical row across both halves. Whitespace and column alignment matter only for human readability; the drawer parses positions, not formatting.
+- `config/glove80.conf` is the Kconfig fragment (currently empty). Add ZMK feature flags here, not in the keymap.
+- `config/default.nix` wires the build: it imports `../src` (the upstream ZMK checkout), overrides `board` for `glove80_lh` and `glove80_rh`, and combines them via `firmware.combine_uf2`. Don't edit this unless changing how the firmware is assembled.
+- `config/info.json` and `config/keymap.json` are emitted by the **Glove80 Layout Editor** webapp. They are not consumed by the Nix build — `glove80.keymap` is the source of truth. They exist so the Layout Editor can round-trip; keep them in sync if you use the editor.
+
+### Layers
+
+Defined in order at the top of `glove80.keymap` as `LAYER_*` `#define`s. The Base layer is the canonical QWERTY surface; everything else is an overlay reached via thumb-cluster keys, tap-dances, or layer-tap behaviors. `&trans` falls through to the layer below; `&none` blocks the key.
+
+| #   | Name      | Purpose                                                                                                                                                                                                                                                                                                                             |
+| --- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | `Base`    | QWERTY with **Miryoku-style home-row mods** (`homey_left/right` for ALT/CTRL/GUI, `index_left/right` for SHIFT on D/K). Includes `lk_qu` (linger Q→qu), `tap_dance_caps_word` (tap = caps-word, double = CapsLock), `shift_spc_uscr` (shift+space → underscore — left-shift only), and the `magic` hold-tap on the bottom-left key. |
+| 1   | `Lower`   | Numpad on right hand, F1–F12, media keys (vol/brightness/transport), and explicit `&to N` layer-jump keys for switching to other layers from a single chord. Reached via the `lower` tap-dance on the inner thumb keys (tap/hold = `&mo`, double-tap = `&to`).                                                                      |
+| 2   | `Cursor`  | Vim-ish navigation cluster: arrows on right hand, line-jump on the left (`LG(LEFT/RIGHT)` = beginning/end of line on macOS), edit shortcuts (`LG(Z/X/C/V)`, Backspace/Delete). Set up for **macOS** — uses `LG(...)` (Cmd) for clipboard and line nav. Reached via `td_cursor` and `thumb_caps`.                                    |
+| 3   | `Spaces`  | OS workspace / virtual-desktop switching using `RC(LEFT/RIGHT/UP/DOWN)`. Reached via the `&mo LAYER_Spaces` thumb key and from Cursor.                                                                                                                                                                                              |
+| 4   | `Gaming`  | Plain QWERTY **without** home-row mods so games don't fire mod-tap on held WASD. Mods are on dedicated thumb-cluster keys instead. Enter via `&to LAYER_Gaming` (typically from Lower); leave via `&to LAYER_Base` on the inner thumb.                                                                                              |
+| 5   | `LabVIEW` | LabVIEW-specific shortcuts using `LG(...)` (Close/Run/Edit/cut/copy/paste). Reached via `&to LAYER_LabVIEW` from Lower.                                                                                                                                                                                                             |
+| 6   | `Magic`   | System layer: Bluetooth profile selection (`bt_0..bt_3`, `BT_CLR`, `BT_CLR_ALL`), RGB underglow controls, `&out OUT_USB`, `&bootloader`, `&sys_reset`. Reached by **holding** the bottom-left magic key (`&magic LAYER_Magic LAYER_Base`) — the tap action runs the RGB-status macro.                                               |
+
+A `Factory` layer (7) and `Blank`/`Trans` template layers exist commented out at the bottom of the keymap — handy starting points when adding a new layer.
+
+### Custom behaviors worth knowing
+
+All defined in the big `behaviors { ... }` block around lines 165–400:
+
+- `homey_left` / `homey_right` — `balanced` hold-tap, `hold-trigger-on-release`, opposite-hand-only triggering. Held = mod, tapped = letter. Tuned via `HOMEY_TAPPING_TERM` (280) and `TYPING_STREAK_TERM` (160, via `global-quick-tap`).
+- `index_left` / `index_right` — `tap-preferred` flavor for the index-finger SHIFT keys; **no** `hold-trigger-on-release` and **no** `global-quick-tap` so SHIFT activates fast (key repeat enabled via `KEY_REPEATING_TERM`). The most recent commit `cb42dbe` swapped which finger gets `index_` vs `homey_` to fix accidental shift non-activations — be careful when touching this.
+- `magic` — hold = `&mo LAYER_Magic`, tap = RGB status macro. Lives on the bottom-outer corners.
+- `lower`, `td_cursor` — tap-dances where first tap/hold = `&mo`, second tap = `&to` (sticky). Lets one key both peek and lock a layer.
+- `thumb`, `thumb_caps` — Miryoku thumb-cluster hold-taps (`&mo` on hold, `&kp` / `&caps_macro` on tap).
+- `lk_qu` — "linger" tap behavior: Q tapped quickly enough types `qu`.
+- `shift_spc_uscr` — shift+space → underscore, gated to left-shift only (per `fb725ac`).
+
+### Generated artifacts
+
+`glove80.svg` and `glove80.yaml` at the repo root are committed by the `draw-keymaps` workflow. Don't hand-edit them — they'll be overwritten on the next PR. `keymap_drawer.config.yaml` controls how they're rendered (key labels, colors, glyph substitutions).
+
+### Reference
+
+`reference/Sunaku's Layout v22 (Engrammer).keymap` is a third-party layout kept for inspiration/comparison. Not part of any build.
+
+## Glove80 hardware operations (pairing, output, recovery)
+
+These are the operations that come up when something goes sideways with the keyboard itself. All of them live on the **Magic layer** (LAYER_Magic, 6), entered by **holding** the bottom-outer corner key (`&magic LAYER_Magic LAYER_Base`). On this keymap the relevant bindings are roughly:
+
+| Operation                         | Behavior                                 | Position on Magic layer                                                        |
+| --------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------ |
+| Select Bluetooth profile 0–3      | `bt_0` / `bt_1` / `bt_2` / `bt_3` macros | thumb cluster + row-5 inner thumbs (each macro also runs `&out OUT_BLE` first) |
+| Switch output to USB              | `&out OUT_USB`                           | center thumb (bottom row)                                                      |
+| Clear *current* BT pairing        | `&bt BT_CLR`                             | top-left corner (F1 position)                                                  |
+| Clear *all* BT pairings           | `&bt BT_CLR_ALL`                         | top-right corner (F10 position)                                                |
+| Enter bootloader (firmware flash) | `&bootloader`                            | row-4 outer corners (both halves)                                              |
+| System reset                      | `&sys_reset`                             | row-5 outer corners (both halves)                                              |
+| RGB underglow controls            | `&rgb_ug RGB_*`                          | left letter cluster (HUI/SAI/SPI/BRI/TOG; HUD/SAD/SPD/BRD/EFF)                 |
+
+### Pairing / re-pairing playbook
+
+A Glove80 holds **4 independent BLE profiles** (slots 0–3). Each slot pairs with one host. To switch between hosts, just select the slot (Magic + the slot's key). To switch back to the wired connection, Magic + center thumb (`OUT_USB`).
+
+When a host *was* paired and now refuses to connect, **the pairing has to be cleared on both ends** — clearing only one side leaves a stale association that prevents re-pairing:
+
+1. On Glove80: hold Magic, select the affected slot, then Magic + top-left to `BT_CLR`.
+2. On the host: remove the Glove80 from its Bluetooth settings (Windows: Settings → Bluetooth → Remove Device; macOS: System Settings → Bluetooth → ⓘ → Forget; Linux: `bluetoothctl remove <mac>`).
+3. Re-initiate pairing from the host. The Glove80 advertises automatically when the slot is empty.
+
+To wipe everything and start clean: Magic + top-right (`BT_CLR_ALL`), then forget the keyboard on every host that had it.
+
+### Flashing firmware
+
+Each half flashes **independently** but with the **same `.uf2` file** — `combine_uf2` packages both halves' images into one file and the bootloader picks the right one. Repeat the procedure once per half.
+
+**Get the file.** After pushing, open the repo on GitHub → Actions → the most recent `Build` run → scroll to **Artifacts** → download `glove80-<branch>-build-<n>.<m>.uf2`. Unzip; the result is a single `.uf2` file. (Filename doesn't matter to the bootloader — no need to rename to `CURRENT.UF2`.)
+
+**Enter bootloader on each half.** Two methods:
+
+1. **From a working keymap (preferred).** Hold the Magic key, tap `&bootloader`. On the factory default layout that's **Magic + Esc** (left half) / **Magic + `'`** (right half). On this keymap `&bootloader` is on the **row-4 outer corner** of each half, so it's Magic + that corner key. Whichever half's Magic key you held is the half that enters bootloader.
+2. **Power-up method (fallback when ZMK is wedged).** Power the half off, plug it in via USB, then power on while holding **C6R6 + C3R3** (Magic + E on left, Magic + PgDn on right, on factory default). Use this if the keyboard isn't responding well enough for method 1.
+
+**Confirm bootloader mode** by the LED next to the power switch:
+
+- **Slow pulsing red** = in bootloader, USB connected, ready to receive a UF2. ✅
+- **Fast flashing red** = in bootloader, but no USB host detected (check cable / port).
+- **Off / solid** = not in bootloader; try again.
+
+A USB mass-storage drive named something like `GLV80LHBOOT` / `GLV80RHBOOT` will appear on the host.
+
+**Flash.** Copy the `.uf2` onto that mass-storage drive (Finder drag, `cp`, whatever). On a successful write the drive disappears, the half reboots into the new firmware, and the LED returns to its normal state. If the drive doesn't disappear, the flash didn't take — check the cable (some charge-only USB-C cables won't enumerate data) and retry.
+
+**Repeat for the other half.** Halves run their own firmware images and their own Bluetooth state — flashing only one leaves them mismatched, which usually shows up as one side's keys not registering or the halves failing to pair to each other.
+
+**After a major version change**, MoErgo recommends a factory reset (clear all BT pairings via `BT_CLR_ALL`, then re-pair) since the BLE bond format can change between releases.
+
+Reference: [MoErgo: Customizing key layout & loading firmware](https://docs.moergo.com/glove80-user-guide/customizing-key-layout/), [Building firmware (Layout Editor guide)](https://docs.moergo.com/layout-editor-guide/building-firmware/).
+
+### Adding / reassigning layers
+
+Two paths:
+
+- **Glove80 Layout Editor** (web app, simpler) — round-trips through `config/keymap.json` and `config/info.json`. Available layer behaviors there: `&mo` (momentary), `&lt` (layer-tap), `&to` (jump-and-stick), `&sl` (sticky-layer for next keypress), plus MoErgo's pseudo-behaviors `&lower` and `&layer` for double-tap-to-stick. Layout Editor does **not** expose `&tog`; if you want toggle, edit the keymap directly.
+- **Editing `glove80.keymap` directly** (the path used in this repo) — preferred for anything beyond the basics. To add a new layer:
+  1. Add a `#define LAYER_<Name> N` at the top, keeping numeric order intact.
+  2. Add a `layer_<Name> { bindings = < ... >; };` node inside `keymap { }` — copy the commented `layer_Trans` template at the bottom as a starting point.
+  3. Bind a key somewhere to enter it (`&mo LAYER_<Name>`, `&to LAYER_<Name>`, or a tap-dance like the existing `lower` / `td_cursor`).
+  4. Push — CI rebuilds firmware and re-renders `glove80.svg`.
+
+  To **remove** a layer, also strip every `&mo`/`&to`/`&tog`/`&lt` reference to its number; `keymap-drawer` will fail loudly if any references survive.
+
+  Reference docs:
+  - [Operating Glove80 wirelessly](https://docs.moergo.com/glove80-user-guide/operating-glove80-wirelessly/) — Bluetooth profiles, output switching, re-pairing
+  - [Layout Editor guide](https://docs.moergo.com/layout-editor-guide/layout-editing/) — Layout Editor's behavior catalog
+  - [Glove80 troubleshooting FAQ](https://docs.moergo.com/glove80-troubleshooting-faqs/) — recovery, stuck halves, etc.
+  - [ZMK behaviors reference](https://zmk.dev/docs/behaviors) — canonical docs for `hold-tap`, `tap-dance`, `mod-morph`, etc.
+
+## Branching & naming
+
+Workflow is **branch → push → PR → merge to `main`**. Every push triggers `build`; PRs touching keymap files trigger `draw-keymaps` which auto-commits the rendered SVG/YAML back to the branch (so a PR usually has a `keymap-drawer render` commit on top of the human ones).
+
+Branch prefixes observed in history (use these — don't invent new ones):
+
+- `feature/<kebab-case-topic>` — by far the most common; used for new layers, behavior tweaks, ergonomic experiments, build/CI changes. Examples: `feature/cursor-layer`, `feature/labview-layer`, `feature/home-row-mods-adjust`, `feature/shift-space-underscore`, `feature/keymap-drawer`.
+- `bugfix/<kebab-case-topic>` — for fixing broken behavior. Example: `bugfix/lower-not-working`.
+- `develop` — exists on the remote but is dormant; merges go directly from `feature/*` to `main`. Don't branch from `develop`.
+
+A few naming-convention notes that come from reading the keymap, not the branches:
+
+- **Behavior identifiers in `behaviors { }`** are `snake_case` and prefixed by what they do: `homey_*`, `index_*`, `thumb*`, `td_*` (tap-dance), `lk_*` (linger), `magic`, `shift_spc_uscr`. The `miryoku_*` labels in `label = "..."` are descriptive only — match them when adding new behaviors in the same family.
+- **Layer node names** in `keymap { }` are `layer_<Name>` with `PascalCase` after the underscore, mirroring the `LAYER_<Name>` `#define`. Keep both in sync when renaming.
+- **Macros** are `snake_case` with a `_macro` suffix (e.g., `rgb_ug_status_macro`, `caps_macro`).
+
+## Commit & PR style
+
+- Commit messages use **gitmoji prefix only** — just the emoji, no `feat:` / `fix:` word label (e.g., `✨ add Cursor layer`, not `✨ feat: add Cursor layer`). Existing history uses the older conventional-commit `feat:`/`fix:` style; new commits should follow the gitmoji-only convention.
+- Don't manually commit `glove80.svg` or `glove80.yaml` — let the `draw-keymaps` workflow do it. If a PR's render looks stale, touching the keymap (even a comment edit — note the `/* comment to trigger keymap-drawing */` line near the top) re-triggers it.
+- The `keymap-drawer` workflow re-runs only when files in its `paths:` filter change.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,57 @@
-# MoErgo Glove80 Custom Configuration for ZMK
+# Glove80 ZMK Config (personal fork)
 
-![MoErgo Logo](moergo_logo.png)
+![MoErgo Glove80](moergo_logo.png)
 
-This repo is the official ZMK configuration of the MoErgo Glove80 wireless split contoured keyboard. Use it to develop your own keymap and easily build your own ZMK firmware to run on your Glove80.
+A personal ZMK firmware configuration for the [MoErgo Glove80](https://www.moergo.com/) wireless split contoured keyboard.
 
-**NOTE: You can also customize the layout of your Glove80 keyboard with the Glove80 Layout Editor webapp. For most users Glove80 Layout Editor is the recommended and simpler option. More information is available at the official MoErgo Glove80 Support site (see resources below).**
+This repo was originally forked from MoErgo's official template, [`moergo-sc/glove80-zmk-config`](https://github.com/moergo-sc/glove80-zmk-config) — full credit to MoErgo for the template, the Glove80 ZMK distribution ([`moergo-sc/zmk`](https://github.com/moergo-sc/zmk)), and the original `glove80.keymap`. Home-row-mod ideas are adapted from [Sunaku's Glove80 layout](https://sunaku.github.io/moergo-glove80-keyboard.html).
 
-These steps will get you using your keymap on your keyboard in the fastest time possible. It uses the GitHub Actions feature to build your firmware online.
+If you're looking for a clean starting template, **use the upstream repo, not this one** — fork [`moergo-sc/glove80-zmk-config`](https://github.com/moergo-sc/glove80-zmk-config) instead.
 
-If you are looking to dig deeper into ZMK and develop new functionality, it is recommended to follow the steps of installing ZMK as found on the official ZMK documentation site (linked below).
+## What's in this fork
+
+- **`config/glove80.keymap`** — the source of truth. Devicetree-format keymap with the layers and custom behaviors below.
+- **`glove80.svg`** — auto-rendered visual of the current keymap. View it on [the GitHub page](./glove80.svg) for a per-layer breakdown.
+- GitHub Actions for building firmware (`.github/workflows/build.yml`) and re-rendering the keymap drawing on PR (`.github/workflows/draw-keymaps.yml`).
+
+### Layers
+
+| #   | Name      | What it does                                                                                       |
+| --- | --------- | -------------------------------------------------------------------------------------------------- |
+| 0   | `Base`    | QWERTY with Miryoku-style home-row mods, linger-Q→qu, tap-dance caps-word, shift+space→underscore. |
+| 1   | `Lower`   | Numpad, F-keys, media controls, layer-jumps.                                                       |
+| 2   | `Cursor`  | Vim-ish nav cluster + Cmd-based clipboard / line-jump shortcuts (macOS).                           |
+| 3   | `Spaces`  | OS workspace / virtual-desktop switching.                                                          |
+| 4   | `Gaming`  | Plain QWERTY without home-row mods.                                                                |
+| 5   | `LabVIEW` | LabVIEW-specific shortcuts.                                                                        |
+| 6   | `Magic`   | System layer — Bluetooth profiles, RGB underglow, USB output, bootloader, sys-reset.               |
+
+### Notable customizations vs. upstream default
+
+- Miryoku-style home-row mods (`homey_*` for ALT/CTRL/GUI, `index_*` for SHIFT) tuned with a typing-streak guard to avoid accidental mod activation while typing fast.
+- A "linger" tap-dance on Q that types `qu` when tapped quickly.
+- Shift+Space (left-shift only) sends underscore.
+- Tap-dances on the layer keys: tap = momentary, double-tap = sticky.
+- A two-step magic key (hold for the system layer, tap for an RGB-underglow status indicator).
+
+## Building & flashing
+
+Builds run automatically on every push. To get a firmware UF2:
+
+1. Push to this repo (or open a PR).
+2. Open the [Actions tab](../../actions) → most recent **Build** run → **Artifacts** → download the `.uf2`.
+3. Put each half of the Glove80 into bootloader mode (Magic + the bootloader key, or hold the bootloader chord while powering on — slow pulsing red LED confirms).
+4. Copy the `.uf2` onto the mass-storage drive that appears. Repeat for the other half.
+
+For full flashing details and the bootloader fallback procedure, see MoErgo's [Customizing key layout & loading firmware](https://docs.moergo.com/glove80-user-guide/customizing-key-layout/) guide.
 
 ## Resources
-- The [official MoErgo Glove80 Support](https://moergo.com/glove80-support) web site. Glove80 documentation and other technical resources.
-- The [official MoErgo Discord Server](https://moergo.com/discord). Instant conversations with other Glove80 users.
 
-- The [official ZMK Documentation](https://zmk.dev/docs) web site. Find the answers to many of your questions about ZMK Firmware.
-- The [official ZMK Discord Server](https://discord.gg/8cfMkQksSB). Instant conversations with other ZMK developers and users. Great technical resource!
+- [MoErgo Glove80 documentation](https://docs.moergo.com/) — official user guide
+- [ZMK documentation](https://zmk.dev/docs) — firmware, behaviors, devicetree reference
+- [`moergo-sc/zmk`](https://github.com/moergo-sc/zmk) — Glove80's ZMK distribution
+- [keymap-drawer](https://github.com/caksoylar/keymap-drawer) — what generates `glove80.svg`
 
-- The [official Glove80 ZMK Distribution](https://github.com/moergo-sc/zmk). Repositiory for ZMK firmware customized for Glove80. 
- 
-## Instructions
-1. Log into, or sign up for, your personal GitHub account.
-2. Create your own repository using this repository as a template ([instructions](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)) and check it out on your local computer.
-3. Edit the keymap file(s) to suit your needs
-4. Commit and push your changes to your personal repo. Upon pushing it, GitHub Actions will start building a new version of your firmware with the updated keymap.
+## License
 
-## Firmware Files
-To locate your firmware files and reflash your Glove80...
-1. log into GitHub and navigate to your personal config repository you just uploaded your keymap changes to.
-2. Click "Actions" in the main navigation, and in the left navigation click the "Build" link.
-3. Select the desired workflow run in the centre area of the page (based on date and time of the build you wish to use). You can also start a new build from this page by clicking the "Run workflow" button.
-4. After clicking the desired workflow run, you should be presented with a section at the bottom of the page called "Artifacts". This section contains the results of your build, in a file called "glove80.uf2"
-5. Download the glove80.uf2
-6. Flash the firmware to Glove80 according to the user documentation on the official Glove80 Glove80 Support website (linked above)
-
-Your keyboard is now ready to use.
+MIT — see [LICENSE](LICENSE).

--- a/config/glove80.keymap
+++ b/config/glove80.keymap
@@ -466,10 +466,10 @@ behaviors {
         layer_Cursor {
             bindings = <
     &none                         &none    &none       &none       &none                                                                                                         &none              &none           &none               &none    &none
-    &none                         &none    &none       &none       &none       &none                                                                                &kp LC(Z)    &kp LC(LEFT)       &none           &kp LC(RIGHT)       &none    &none
-    &none                         &none    &none       &none       &none       &none                                                                                &kp LC(X)    &kp DEL            &kp UP          &kp BSPC            &none    &none
-    &none                         &kp LALT &kp LCTRL   &kp LSHFT   &kp LGUI    &none                                                                                &kp LC(C)    &kp LEFT           &kp DOWN        &kp RIGHT           &none    &none
-    &none                         &none    &none       &none       &none       &none   &none  &none  &none                &mo LAYER_Spaces &kp RALT   &kp RSHFT     &kp LC(V)    &kp HOME           &kp PG_UP       &kp PG_DN           &kp END  &none
+    &none                         &none    &none       &none       &none       &none                                                                                &kp LG(Z)    &kp LG(LEFT)       &none           &kp LG(RIGHT)       &none    &none
+    &none                         &none    &none       &none       &none       &none                                                                                &kp LG(X)    &kp DEL            &kp UP          &kp BSPC            &none    &none
+    &none                         &kp LALT &kp LCTRL   &kp LSHFT   &kp LGUI    &none                                                                                &kp LG(C)    &kp LEFT           &kp DOWN        &kp RIGHT           &none    &none
+    &none                         &none    &none       &none       &none       &none   &none  &none  &none                &mo LAYER_Spaces &kp RALT   &kp RSHFT     &kp LG(V)    &kp HOME           &kp PG_UP       &kp PG_DN           &kp END  &none
     &magic LAYER_Magic LAYER_Base &none    &none       &none       &none               &none  &none  &to LAYER_Base       &to LAYER_Base   &kp ENTER  &kp SPACE                  &none              &none           &none               &none    &none
             >;
         };

--- a/config/glove80.keymap
+++ b/config/glove80.keymap
@@ -154,8 +154,8 @@
 // under Settings > Advanced Settings in the Glove80 Layout Editor! //
 //////////////////////////////////////////////////////////////////////
 //
-// Justin's version of...
-//   Sunaku's Layout v21 
+// Adapted from...
+//   Sunaku's Layout v21
 // mostly to steal the home-row-mods
 //
 // https://sunaku.github.io/moergo-glove80-keyboard.html

--- a/glove80.svg
+++ b/glove80.svg
@@ -1345,7 +1345,7 @@ path.combo {
 </g>
 <g transform="translate(1000, 120)" class="key keypos-16">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
-<text x="0" y="0" class="key tap">Ctl+Z</text>
+<use href="#mdi:undo" xlink:href="#mdi:undo" x="-13" y="-13" height="26" width="26.0" class="key tap glyph mdi:undo"/>
 </g>
 <g transform="translate(1080, 120)" class="key keypos-17">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
@@ -1393,7 +1393,7 @@ path.combo {
 </g>
 <g transform="translate(1000, 200)" class="key keypos-28">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
-<text x="0" y="0" class="key tap">Ctl+X</text>
+<use href="#mdi:content-cut" xlink:href="#mdi:content-cut" x="-13" y="-13" height="26" width="26.0" class="key tap glyph mdi:content-cut"/>
 </g>
 <g transform="translate(1080, 200)" class="key keypos-29">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
@@ -1441,7 +1441,7 @@ path.combo {
 </g>
 <g transform="translate(1000, 280)" class="key keypos-40">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
-<text x="0" y="0" class="key tap">Ctl+C</text>
+<use href="#mdi:content-copy" xlink:href="#mdi:content-copy" x="-13" y="-13" height="26" width="26.0" class="key tap glyph mdi:content-copy"/>
 </g>
 <g transform="translate(1080, 280)" class="key keypos-41">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
@@ -1514,7 +1514,7 @@ path.combo {
 </g>
 <g transform="translate(1000, 360)" class="key keypos-58">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>
-<text x="0" y="0" class="key tap">Ctl+V</text>
+<use href="#mdi:content-paste" xlink:href="#mdi:content-paste" x="-13" y="-13" height="26" width="26.0" class="key tap glyph mdi:content-paste"/>
 </g>
 <g transform="translate(1080, 360)" class="key keypos-59">
 <rect rx="4" ry="4" x="-38" y="-38" width="77" height="77" class="key"/>

--- a/glove80.yaml
+++ b/glove80.yaml
@@ -1,4 +1,4 @@
-layout: {qmk_keyboard: glove80}
+layout: {zmk_keyboard: glove80}
 layers:
   Base:
   - F1
@@ -179,19 +179,19 @@ layers:
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
-  - Ctl+Z
-  - Ctl+$$mdi:arrow-left-bold$$
+  - $$mdi:undo$$
+  - Gui+$$mdi:arrow-left-bold$$
   - {t: '$$mdi:minus-circle-outline$$', type: none}
-  - Ctl+$$mdi:arrow-right-bold$$
-  - {t: '$$mdi:minus-circle-outline$$', type: none}
-  - {t: '$$mdi:minus-circle-outline$$', type: none}
+  - Gui+$$mdi:arrow-right-bold$$
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
   - {t: '$$mdi:minus-circle-outline$$', type: none}
-  - Ctl+X
+  - {t: '$$mdi:minus-circle-outline$$', type: none}
+  - {t: '$$mdi:minus-circle-outline$$', type: none}
+  - $$mdi:content-cut$$
   - $$mdi:backspace-reverse$$
   - $$mdi:arrow-up-bold$$
   - {t: '$$mdi:backspace$$', type: backspace}
@@ -203,7 +203,7 @@ layers:
   - $$mdi:apple-keyboard-shift$$
   - $$mdi:apple-keyboard-command$$
   - {t: '$$mdi:minus-circle-outline$$', type: none}
-  - Ctl+C
+  - $$mdi:content-copy$$
   - $$mdi:arrow-left-bold$$
   - $$mdi:arrow-down-bold$$
   - $$mdi:arrow-right-bold$$
@@ -221,7 +221,7 @@ layers:
   - Spaces
   - $$mdi:apple-keyboard-option$$
   - $$mdi:apple-keyboard-shift$$
-  - Ctl+V
+  - $$mdi:content-paste$$
   - HOME
   - PG UP
   - PG DN


### PR DESCRIPTION
## Summary
- ⌨️ Cursor layer: swap `LC(...)` → `LG(...)` so clipboard ops (Z/X/C/V) and the line-jump arrows use Cmd instead of Ctrl.
- 📝 Add `CLAUDE.md` — comprehensive guide for AI coding assistants (build flow, layers, behaviors, branching, tagging, BT/flash playbook, public-repo guardrail, post-push build monitor).
- 📝 Streamline `README.md` — credit `moergo-sc/glove80-zmk-config` and Sunaku, redirect template-seekers there, summarize this fork's layers & customizations.
- 🧹 Drop maintainer's first name from the keymap header comment.

## Notes
- 🍏 Cmd+Left / Cmd+Right go to start/end of line on macOS (not previous/next word). If you'd rather have Option-based word-jump on those two specific keys, swap `LG(LEFT)` / `LG(RIGHT)` → `LA(LEFT)` / `LA(RIGHT)`.
- 🎨 The `keymap-drawer` workflow will append a `keymap-drawer render` commit to this branch with the updated `glove80.svg` / `glove80.yaml`.
- 🏷️ Tag `v14-cursor-layer-mac` after merge (per the documented convention).

## Test plan
- [ ] CI build is green and produces a `.uf2` artifact
- [ ] Flash both halves; confirm Cursor layer Cmd+X/C/V/Z work in a Mac app
- [ ] Confirm Cmd+Left / Cmd+Right behave as line-start / line-end (or decide to swap to Option for word-jump)
- [ ] Confirm no Base / Lower / LabVIEW regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates key bindings on the `Cursor` layer (Ctrl→Cmd) which can change editing/navigation behavior across OSes; remaining changes are documentation and generated render artifacts with low functional risk.
> 
> **Overview**
> Converts the `Cursor` layer clipboard and line-navigation shortcuts from `LC(...)` to `LG(...)` (Ctrl → Cmd) to better match macOS behavior.
> 
> Adds a new `CLAUDE.md` with repository-specific workflow/usage guidance, refreshes `README.md` to describe this as a personal fork and summarize layers/build steps, and updates `.gitignore` to exclude a local `builds/` artifact cache. Regenerates `glove80.svg`/`glove80.yaml` to reflect the keymap changes (including switching the drawer metadata to `zmk_keyboard`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3216aa7b8104510d90d8961d0eee93cce99601e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->