### PR TITLE
📝 Research notes: split-RGB bug status + firmware-update procedure

### DIFF
--- a/docs/firmware-update-procedure.md
+++ b/docs/firmware-update-procedure.md
@@ -1,0 +1,142 @@
+# Updating the firmware base — procedure & rationale
+
+## TL;DR
+
+Updating "the firmware" on this Glove80 is a **one-line change** to `.github/workflows/build.yml` — bump the `ref:` of the `moergo-sc/zmk` checkout to a newer release tag. It is **not** a `git merge` from any other repo.
+
+This works because: this is a *config* repo — the firmware itself lives in a separate repo (`moergo-sc/zmk`) and is fetched at build time. There's nothing to merge, nothing to rebase, no upstream conflicts. Bump the ref, push, flash the resulting `.uf2`, re-pair if needed, done.
+
+## "Are we forked from the glove80 repo?" — No, but close
+
+It feels like a fork because the repo started from MoErgo's structure, but on GitHub it's actually a **template instance**, not a git fork:
+
+```
+gh repo view --json isFork,parent,templateRepository
+{
+  "isFork": false,
+  "parent": null,
+  "templateRepository": { "owner": { "login": "moergo-sc" }, "name": "glove80-zmk-config" }
+}
+```
+
+The distinction matters:
+
+|                             | Git fork                          | Template instance (this repo)                                         |
+| --------------------------- | --------------------------------- | --------------------------------------------------------------------- |
+| Created via                 | "Fork" button                     | "Use this template" button                                            |
+| Shared git history          | Yes — common ancestor commit      | No — independent histories from day 1                                 |
+| GitHub "Sync fork" UI       | Yes                               | No                                                                    |
+| `git pull <upstream>` works | Cleanly (mostly)                  | Only with `--allow-unrelated-histories`, and conflicts will be brutal |
+| Tracks upstream by default  | Yes (`origin`/`upstream` remotes) | No — only `origin` (your own repo) is configured                      |
+
+So: **no automatic way to "sync upstream"** at the GitHub level, and trying to merge upstream's git tree directly would create unrelated-history conflicts on every file that has diverged (most importantly `config/glove80.keymap`, which is a 33 KB heavily-modified file vs. upstream's 9 KB vanilla template).
+
+### Why "template instance" instead of "fork"?
+
+Probably visibility. **GitHub forks inherit visibility from the parent** — you can't fork a public repo and make the fork private. To get a private starting point, you have to use "Use this template" (or clone and push to a new private repo manually). That trade-off — privacy in exchange for losing the fork's automatic sync UI — was the likely original motivation for this repo's structure. The repo has since gone public, so the privacy reason no longer applies, but the consequences persist: upstream sync is manual no matter what.
+
+## "Can we just merge the glove80 firmware into ours and expect it to work?" — Two questions in one
+
+The phrase "merge the glove80 firmware" conflates two different things:
+
+### 1. The actual firmware code (ZMK) → not a merge, just a ref bump
+
+The Glove80 firmware source lives in **`moergo-sc/zmk`** — a *separate* repo from the config template. This repo's `build.yml` checks it out at build time:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    repository: moergo-sc/zmk
+    ref: v24.02            # ← THIS is what controls the firmware version
+    path: src
+```
+
+Updating the firmware = changing `ref: v24.02` to a newer tag (e.g., `ref: v25.11`). That's the entire change. Available tags: see [`moergo-sc/zmk/releases`](https://github.com/moergo-sc/zmk/releases).
+
+For comparison, upstream's `moergo-sc/glove80-zmk-config` uses `ref: main` so it always picks up whatever's latest on moergo's `main` branch. That's lower friction but trades for stability — pinning a tag means the build is reproducible and won't suddenly change under you.
+
+### 2. The config-repo template files → cherry-pick, don't merge
+
+The template repo (`moergo-sc/glove80-zmk-config`) has its own files that *could* drift from this repo over time: `build.yml`, `default.nix`, `info.json`, `glove80.keymap` (the vanilla starting point), Dockerfile, etc. Comparing as of 2026-05:
+
+| File                          | Upstream                                                      | This repo                                                                                     | Status                                  |
+| ----------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `.github/workflows/build.yml` | `ref: main`, builds on `pull_request` too, `cachix/*@v25/v14` | `ref: v24.02`, push-only, `cachix/*@v27/v15`, branch-named artifacts, ships `glove80.svg` too | **Diverged in both directions**         |
+| `config/default.nix`          | Accepts `firmware ?` parameter                                | Hardcodes `import ../src {}`                                                                  | Functionally equivalent for CI          |
+| `config/glove80.conf`         | Empty                                                         | Empty                                                                                         | Same                                    |
+| `config/glove80.keymap`       | Vanilla template (~9 KB)                                      | Heavily customized (~33 KB)                                                                   | **Never sync — this repo owns it**      |
+| `config/info.json`            | Layout Editor metadata                                        | Layout Editor metadata                                                                        | Likely safe to sync if upstream changes |
+| `config/keymap.json`          | Layout Editor metadata                                        | Layout Editor metadata                                                                        | Tracks `glove80.keymap` — don't sync    |
+
+Recent upstream commits to the template (last few years):
+
+- 2025-05-26 — Windows `build.bat` script, LF line endings
+- 2024-04-04 — Dockerfile improvements, syntax highlighting for `.keymap`
+- 2023-10-07 — Add Dockerfile for local builds
+
+The template moves slowly. Most updates are infrastructure (Docker, build scripts) that this repo doesn't use anyway because builds run in CI on Nix.
+
+## Recommended procedure to update firmware
+
+This is a feature-branch task. Follow it like any other change in this repo.
+
+```bash
+git checkout main && git pull
+git checkout -b feature/firmware-bump-v25-11   # or whatever target version
+```
+
+Edit `.github/workflows/build.yml`:
+
+```diff
+       - uses: actions/checkout@v4
+         with:
+           repository: moergo-sc/zmk
+-          ref: v24.02
++          ref: v25.11
+           path: src
+```
+
+Then:
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "🔧 Bump moergo-sc/zmk pinned ref to v25.11"
+git push -u origin feature/firmware-bump-v25-11
+gh pr create --title "🔧 Bump firmware base to moergo-sc/zmk v25.11"
+```
+
+CI runs the Nix build. If green, download the artifact (`gh run download <id> --dir ./builds/`) and flash both halves.
+
+### Post-flash checklist
+
+After flashing a new firmware base, in order:
+
+1. **Confirm both halves boot** and the keymap looks right.
+2. **`BT_CLR_ALL` and re-pair every host.** MoErgo's docs explicitly recommend this on major version jumps because the BLE bond format can change between releases.
+3. **Configuration factory reset on the right half**, per MoErgo's troubleshooting FAQ: charge the right half via USB, power-cycle both halves, toggle RGB on with `magic+t`, confirm RGB works on both halves, toggle RGB off, wait ≥1 minute before powering off — needed for the new config to persist.
+4. **Sanity-check the keymap layers.** Each layer should still behave as in the keymap file. ZMK occasionally renames keycodes or changes behavior semantics between major versions — read the release notes between the old and new tag.
+5. **Re-evaluate the workarounds in `glove80.keymap`** — see `docs/split-rgb-status.md`. The commented-out RGB-on-layer-switch macros at `config/glove80.keymap:96–113` may be safe to re-enable on `v25.01+`.
+
+## Picking a target version
+
+Look at [`moergo-sc/zmk/releases`](https://github.com/moergo-sc/zmk/releases) and pick the latest stable (non-beta, non-pre-release). At time of writing (2026-05) the recommendation is `v25.11`.
+
+Avoid `ref: main` for this repo. Upstream uses it because they're the maintainers and they want continuous testing; for a personal config you want reproducibility. Pinning a tag means a build kicked off today and a build kicked off in six months will produce identical firmware unless you choose to bump.
+
+## What this repo's `build.yml` already does *better* than upstream
+
+Worth noting before you ever consider syncing `build.yml` from upstream — this repo is **ahead** in three places:
+
+- `cachix/install-nix-action@v27` (upstream still on v25)
+- `cachix/cachix-action@v15` (upstream still on v14)
+- Branch-named artifact filenames (`glove80-<branch>-build-<n>.<m>.uf2`) — upstream uploads a generic `glove80.uf2` that is a pain to tell apart across runs.
+- Uploads `glove80.svg` alongside the firmware — useful for at-a-glance review.
+
+Don't accidentally lose any of that by bulk-overwriting `build.yml` from upstream. If you ever do sync, do it as a per-line cherry-pick.
+
+## Sources
+
+- [`moergo-sc/zmk` releases](https://github.com/moergo-sc/zmk/releases) — pick the target tag from here
+- [`moergo-sc/glove80-zmk-config`](https://github.com/moergo-sc/glove80-zmk-config) — upstream template
+- [Glove80 Troubleshooting FAQs (MoErgo)](https://docs.moergo.com/glove80-troubleshooting-faqs/) — re-pair / RGB factory reset procedure
+- [`docs/split-rgb-status.md`](./split-rgb-status.md) — companion note: which v25.x release first contains the split-RGB fix

--- a/docs/split-rgb-status.md
+++ b/docs/split-rgb-status.md
@@ -1,0 +1,81 @@
+# Split-keyboard RGB on Glove80 — bug status (as of 2026-05)
+
+## TL;DR
+
+The "RGB control only affects the left half" bug **has been fixed upstream** and is included in moergo's `v25.01` release and every release after it. **This repo's CI still pins `moergo-sc/zmk@v24.02`** (`.github/workflows/build.yml`), which is from **2024-02-16** — about 7 months before the fix shipped. So on the firmware actually running on this Glove80, the bug is still present. Bumping the pinned ref to **`v25.11`** (the current latest moergo release, 2025-11-26) would pick up the fix.
+
+This note is research only — no code, keymap, or workflow changes. See "Why we kept the workaround" at the bottom for the existing in-keymap workaround.
+
+## The bug
+
+When `&rgb_ug RGB_*` is invoked from inside a macro, hold-tap, mod-morph, tap-dance, or sticky-key (collectively: "nested behaviors"), the RGB command is only delivered to the **central** half (the left half on Glove80). The peripheral (right) half doesn't receive the command. Calling `&rgb_ug ...` directly from a keymap binding works fine on both halves — the bug is specifically about *nested* invocations.
+
+Concretely in this repo, the consequence is the commented-out RGB-on-layer-switch macros at `config/glove80.keymap:96–113` (and the surrounding comment block):
+
+```c
+//    Layer switch with RGB is disabled because an
+//    upstream ZMK bug means RGBs in macros only
+//    light up the left (main) side of the keyboard
+```
+
+That comment is accurate against the firmware actually flashed today. It would no longer be accurate after a bump to v25.01+.
+
+## Upstream resolution
+
+| Item                | Reference                                                                                                                                                | Date                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| Original bug report | [zmkfirmware/zmk #1347 — `&rgb_ug RGB_COLOR_HSB on split keyboard is not global when used within macro`](https://github.com/zmkfirmware/zmk/issues/1347) | filed 2022-06-16      |
+| Related bug         | [zmkfirmware/zmk #1494](https://github.com/zmkfirmware/zmk/issues/1494) (broader "behavior locality" bucket)                                             | —                     |
+| Earlier attempt     | [zmkfirmware/zmk #1630](https://github.com/zmkfirmware/zmk/pull/1630) (covered macros only)                                                              | —                     |
+| **Final fix**       | [zmkfirmware/zmk #2409 — `fix(split): Make locality work for nested behaviors`](https://github.com/zmkfirmware/zmk/pull/2409)                            | **merged 2024-09-23** |
+| Issue #1347 closed  | by maintainer caksoylar referencing #2409                                                                                                                | 2024-09-23            |
+
+PR #2409 generalizes the locality fix beyond macros: it covers macros, mod-morphs, hold-taps, tap-dances, sticky keys, and combos invoking global behaviors like RGB underglow. The implementation adds a `source` field to `zmk_behavior_binding_event` so nested behaviors propagate the originating side correctly when split-locality routes a command to "global" / both halves.
+
+## Moergo's release pipeline
+
+`moergo-sc/zmk` cherry-picks the fix as commit [`9e36ebd5 feat(split): Make locality work nested behavior invocations`](https://github.com/moergo-sc/zmk/commit/9e36ebd52587c0364562057466a458fdcfcdc685). Spot-checking which moergo release tags contain that commit:
+
+| moergo tag      | Tagged     | Contains the fix?            |
+| --------------- | ---------- | ---------------------------- |
+| `v23.12`        | 2023-12-18 | ❌                            |
+| `v24.02`        | 2024-02-16 | ❌ ← **what this repo pins**  |
+| `v24.08-beta.1` | 2024-07-24 | ❌                            |
+| `v25.01`        | 2025-01-21 | ✅ first release with the fix |
+| `v25.05`        | 2025-05-14 | ✅                            |
+| `v25.08`        | 2025-08-27 | ✅                            |
+| `v25.11`        | 2025-11-26 | ✅ current latest             |
+
+(Verified by walking `app/src/behaviors/behavior_macro.c` history at each tag via the GitHub API — the fix commit appears in v25.01 and every later tag, and is absent from v24.02.)
+
+A note on the commit's authored date: the commit shows `2023-01-17` because it carries the original PR #2409 author date (and a co-author trailer to user `tokazio`, who first reported the regression in their Sofle config). The actual landing in moergo's tree was after upstream merge.
+
+## What this repo currently pins vs. upstream template
+
+- **This repo:** `.github/workflows/build.yml` pins `repository: moergo-sc/zmk` at `ref: v24.02`. The build runs against a 2-year-old ZMK that does not have the fix.
+- **Upstream `moergo-sc/glove80-zmk-config` template:** now uses `ref: main` — i.e., it rides moergo's `main` branch and gets the fix automatically.
+
+So the upstream template's stance is "ride main"; this fork froze its ref at v24.02 some time ago and the world moved on.
+
+## Implications (no action taken)
+
+If the pinned ref is ever bumped to a release ≥ `v25.01` (most likely target: `v25.11` or whatever's current at the time):
+
+1. The commented-out layer-switch RGB macros at `config/glove80.keymap:96–113` could be uncommented and would work on both halves. Worth re-reading the `to_layer_4_rgb_on` / `to_layer_0_rgb_off` definitions before re-enabling — they were written against an older ZMK API and may need minor adjustments.
+2. Other RGB-in-macro / RGB-in-tap-dance compositions that were avoided would become available.
+3. Unrelated changes between v24.02 and v25.11 will also come along — Bluetooth bond format, behaviors API surface, kconfig defaults, board defs. After flashing, MoErgo's docs recommend `BT_CLR_ALL` + re-pair on every host, and a "Configuration factory reset" if the right half misbehaves.
+4. Worth a build-and-test pass on a feature branch before merging — exactly the kind of change that benefits from the existing CI artifact + flash-and-test loop.
+
+## Why we kept the workaround
+
+Glove80 owners who were on early-2024 firmware learned to write RGB triggers either at the *outer* keymap level (works on both halves) or simply to leave the layer-switch RGB feedback off. The current keymap takes the second path: macros for layer-switch + RGB are defined but commented out, and the bottom-left "magic" key's tap action is `rgb_ug_status_macro` (single-binding `&rgb_ug RGB_STATUS`) rather than a multi-step macro — that single binding is *not* a nested invocation, so it works fine on both halves even on v24.02. Worth preserving that pattern: top-level `&rgb_ug` bindings work everywhere; nested `&rgb_ug` only works once we're on v25.01+.
+
+## Sources
+
+- ZMK issue tracker — [#1347 (closed)](https://github.com/zmkfirmware/zmk/issues/1347), [#1494](https://github.com/zmkfirmware/zmk/issues/1494), [#3017 (open, related architecture concern)](https://github.com/zmkfirmware/zmk/issues/3017)
+- ZMK PR — [#2409 (merged 2024-09-23)](https://github.com/zmkfirmware/zmk/pull/2409)
+- moergo-sc/zmk commit — [`9e36ebd5`](https://github.com/moergo-sc/zmk/commit/9e36ebd52587c0364562057466a458fdcfcdc685)
+- moergo-sc/zmk releases — [GitHub releases page](https://github.com/moergo-sc/zmk/releases)
+- moergo-sc/glove80-zmk-config — [upstream template `build.yml`](https://github.com/moergo-sc/glove80-zmk-config/blob/main/.github/workflows/build.yml) (rides `main`)
+- MoErgo troubleshooting docs — [Glove80 Troubleshooting FAQs](https://docs.moergo.com/glove80-troubleshooting-faqs/)
+- ZMK feature docs — [Lighting](https://zmk.dev/docs/features/lighting), [Split keyboards](https://zmk.dev/docs/features/split-keyboards), [Underglow behavior](https://zmk.dev/docs/keymaps/behaviors/underglow)


### PR DESCRIPTION
## Summary
Two related research-only docs under a new `docs/` directory. No code, keymap, workflow, or behavior changes — just findings.

- 📄 `docs/split-rgb-status.md` — the long-standing ZMK bug where `&rgb_ug` invoked from inside macros / hold-taps / tap-dances only affected the central (left) half. Fixed upstream by [zmkfirmware/zmk#2409](https://github.com/zmkfirmware/zmk/pull/2409) (merged 2024-09-23). First moergo release containing the fix is **v25.01** (2025-01-21). This repo currently pins `v24.02` so the existing workaround in `config/glove80.keymap:96–113` is still load-bearing on flashed firmware.
- 📄 `docs/firmware-update-procedure.md` — how to actually update the firmware base. Key insight: this repo is a **template instance**, not a git fork (`isFork: false, parent: null`), so there is no automatic upstream sync. But updating firmware doesn't need a sync — the firmware itself lives in `moergo-sc/zmk` and is referenced via one line in `build.yml`. Bumping is a one-line ref change, not a merge. Includes the fork-vs-template story (visibility-inheritance forced the template route), file-level diff with upstream, and a copy-pasteable bump procedure with post-flash checklist.

## Notes
- 🔄 Companion: see the `docs/firmware-update-procedure.md` for what to do *with* the v25.01 finding from the split-RGB doc.
- 🏷️ Tag after merge: `v15-firmware-research-notes` (per repo convention — see CLAUDE.md).

## Test plan
- [ ] CI build green on the no-op docs change
- [ ] No diff to `config/`, `.github/workflows/`, or any keymap files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation only and does not change firmware builds, workflows, or keymap behavior.
> 
> **Overview**
> Adds two new docs under `docs/` capturing firmware-maintenance research.
> 
> `docs/firmware-update-procedure.md` documents how to bump the pinned `moergo-sc/zmk` version via a one-line `ref` change in `.github/workflows/build.yml`, plus a post-flash checklist and cautions about syncing upstream template files. `docs/split-rgb-status.md` records the upstream fix status for the split-keyboard nested-RGB behavior bug and notes that the current pinned `v24.02` still requires the existing keymap workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fbb1d4ac899900df0c6ed55ca11f876a23d672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->